### PR TITLE
Stop exposing isrc search

### DIFF
--- a/src/lib/apple-music/index.ts
+++ b/src/lib/apple-music/index.ts
@@ -42,12 +42,19 @@ export const search = async (
   return Promise.resolve(songs);
 };
 
-export const findSongByIsrc = (query: string): Promise<Song> => {
+const findSongByIsrc = (song: Song): Promise<Song> => {
   return Promise.reject("Not Implemented");
 };
 
-export const play = async (url: string): Promise<any> => {
-  await MusicKit.getInstance().setQueue({ url: url });
+export const play = async (song: Song): Promise<any> => {
+  const APPLE_MUSIC_BASE_URL = "https://music.apple.com";
+  let appleMusicSong = song;
+
+  if (!song.url.includes(APPLE_MUSIC_BASE_URL)) {
+    appleMusicSong = await findSongByIsrc(song);
+  }
+
+  await MusicKit.getInstance().setQueue({ url: appleMusicSong.url });
 
   return MusicKit.getInstance().play();
 };

--- a/src/lib/music-interface/music.ts
+++ b/src/lib/music-interface/music.ts
@@ -1,6 +1,6 @@
 import * as AppleMusic from "../apple-music";
 import * as Spotify from "../spotify";
-import { SearchType } from "../constants";
+import { SearchType, Song } from "../constants";
 
 export type Platform = "apple" | "spotify";
 
@@ -42,12 +42,8 @@ class Music {
     return getLib(this.platform).search(query, searchTypes, this.authToken);
   };
 
-  findSongByIsrc = (query: string) => {
-    return getLib(this.platform).findSongByIsrc(query, this.authToken);
-  };
-
-  play = (url: string) => {
-    return getLib(this.platform).play(url, this.authToken);
+  play = (song: Song) => {
+    return getLib(this.platform).play(song, this.authToken);
   };
 
   pause = () => {

--- a/src/lib/spotify/index.ts
+++ b/src/lib/spotify/index.ts
@@ -49,21 +49,25 @@ export const search = async (
   return Promise.resolve(transformSongs(responseJson.tracks.items));
 };
 
-export const findSongByIsrc = (
-  query: string,
-  authToken: string
-): Promise<Song> => {
+const findSongByIsrc = (song: Song, authToken: string): Promise<Song> => {
   return Promise.reject("Not Implemented");
 };
 
-export const play = (url: string, authToken: string): Promise<any> => {
+export const play = async (song: Song, authToken: string): Promise<any> => {
   const { playerId } = getPlayerOptions();
+  const SPOTIFY_BASE_URL = "spotify";
+
+  let spotifySong = song;
+
+  if (!song.url.includes(SPOTIFY_BASE_URL)) {
+    spotifySong = await findSongByIsrc(song, authToken);
+  }
 
   return fetch(
     `https://api.spotify.com/v1/me/player/play?device_id=${playerId}`,
     {
       method: "PUT",
-      body: JSON.stringify({ uris: [url] }),
+      body: JSON.stringify({ uris: [spotifySong.url] }),
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${authToken}`,

--- a/src/pages/room-page/room-page.tsx
+++ b/src/pages/room-page/room-page.tsx
@@ -28,7 +28,7 @@ export const RoomPage = () => {
 
         const currentSong: Song = songList[songKeys[0]];
 
-        await music.play(currentSong.url);
+        await music.play(currentSong);
       });
   }, [firebase, music, roomKey]);
 


### PR DESCRIPTION
Exposing the isrc search is bad because it complicates our application code. Instead, this sets us up so that each platform figures out when it needs to do an isrc search